### PR TITLE
Fixed an issue where it did not work on Firmware v1.2.0

### DIFF
--- a/application.fam
+++ b/application.fam
@@ -1,5 +1,5 @@
 App(
-    appid="TAMA_P1",
+    appid="tama_p1",
     name="TAMA P1",
     apptype=FlipperAppType.EXTERNAL,
     entry_point="tama_p1_app",

--- a/tama_p1.c
+++ b/tama_p1.c
@@ -457,17 +457,20 @@ static void tama_p1_draw_callback(Canvas* const canvas, void* cb_ctx) {
     furi_mutex_release(mutex);
 }
 
-static void tama_p1_input_callback(InputEvent* input_event, FuriMessageQueue* event_queue) {
-    furi_assert(event_queue);
+static void tama_p1_input_callback(InputEvent* input_event, void* context) {
+    furi_assert(context);
 
     TamaEvent event = {.type = EventTypeInput, .input = *input_event};
+
+    FuriMessageQueue* event_queue = (FuriMessageQueue*)context;
     furi_message_queue_put(event_queue, &event, FuriWaitForever);
 }
 
-static void tama_p1_update_timer_callback(FuriMessageQueue* event_queue) {
-    furi_assert(event_queue);
+static void tama_p1_update_timer_callback(void* context) {
+    furi_assert(context);
 
     TamaEvent event = {.type = EventTypeTick};
+    FuriMessageQueue* event_queue = (FuriMessageQueue*)context;
     furi_message_queue_put(event_queue, &event, 0);
 }
 

--- a/tama_p1.c
+++ b/tama_p1.c
@@ -1,4 +1,5 @@
 #include <furi.h>
+#include <furi_hal_bus.h>
 #include <gui/gui.h>
 #include <input/input.h>
 #include <storage/storage.h>
@@ -711,6 +712,7 @@ static int32_t tama_p1_worker(void* context) {
         }
     }
     LL_TIM_DisableCounter(TIM2);
+    furi_hal_bus_disable(FuriHalBusTIM2);
     furi_mutex_release(mutex);
     return 0;
 }
@@ -753,6 +755,7 @@ static void tama_p1_init(TamaApp* const ctx) {
     if(ctx->rom != NULL) {
         // Init TIM2
         // 64KHz
+        furi_hal_bus_enable(FuriHalBusTIM2);
         LL_TIM_InitTypeDef tim_init = {
             .Prescaler = 999,
             .CounterMode = LL_TIM_COUNTERMODE_UP,


### PR DESCRIPTION
When I tried to build this on Firmware v1.2.0, I encountered some failures, so I fixed them.  
* Fixed the arguments of `tama_p1_input_callback` and `tama_p1_update_timer_callback`.  
* Fixed an issue where the beep sound kept playing after startup.  
  * TIM2 needed to be enabled, so I enabled it.